### PR TITLE
Add Deep Q-Learning Portfolio to Reinforcement Learning section

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -101,6 +101,8 @@ website:
       
       - section: "🤖 Reinforcement Learning"
         contents:
+          - text: "Deep Q-Learning Portfolio"
+            href: deep_q_learning_portfolio.qmd
           - text: "Pareto Front Strategy"
             href: pareto_front_reinforcement.qmd
           - text: "RL Decision Algorithms"


### PR DESCRIPTION
Added deep_q_learning_portfolio.qmd to the sidebar under the Reinforcement Learning section, positioned as the first item to highlight this comprehensive DQN implementation for portfolio allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)